### PR TITLE
Make HTTP API listen on 0.0.0.0 like other services

### DIFF
--- a/application/xiu/src/api.rs
+++ b/application/xiu/src/api.rs
@@ -114,8 +114,8 @@ pub async fn run(producer: StreamHubEventSender, port: usize) {
         .route("/get_stream_status", get(status))
         .route("/kick_off_client", post(kick));
 
-    log::info!("Http api server listening on http://:{}", port);
-    axum::Server::bind(&([127, 0, 0, 1], port as u16).into())
+    log::info!("Http api server listening on http://0.0.0.0:{}", port);
+    axum::Server::bind(&([0, 0, 0, 0], port as u16).into())
         .serve(app.into_make_service())
         .await
         .unwrap();


### PR DESCRIPTION
## PR Summary
Makes the HTTP API listen on 0.0.0.0 like the rest of the services :)

This is required mainly to allow every service to operate inside of a container, where 127.0.0.1 isn't very useful as you can't hit the service from the outside.

## Issues
Fixes #86 

## How to test

Run the application as normal with your desired config. Here's an example config based on the one I'm using for my app:

```toml
[hls]
enabled = true
port = 8080
need_record = true

[rtmp]
enabled = true
port = 1935
```

Command like the I'm using to run this locally:

```shell
cargo run --bin xiu -- -c ~/path/to/your/config.toml
```

You should see the http api now listed as running on 0.0.0.0:8000 or however you've configured it.

```
...truncated...
[2023-12-25T21:03:19Z INFO  hls::server] Hls server listening on http://0.0.0.0:8080
[2023-12-25T21:03:19Z INFO  rtmp::rtmp] Rtmp server listening on tcp://0.0.0.0:1935
[2023-12-25T21:03:19Z INFO  xiu::api] Http api server listening on http://0.0.0.0:8000
```

## Next Steps
I just wanted to get this out there for now, but soon I'd like to make a PR that adds a `--host` as well as `host` or maybe `address` config options to each of the target services to make this truly customizable for any strange configuration end users might need :)