### PR TITLE
fix RTMP publish single AAC from ffmpeg client.

### DIFF
--- a/library/container/flv/src/demuxer.rs
+++ b/library/container/flv/src/demuxer.rs
@@ -185,7 +185,10 @@ impl FlvAudioTagDemuxer {
         if tag_header.sound_format == SoundFormat::AAC as u8 {
             match tag_header.aac_packet_type {
                 aac_packet_type::AAC_SEQHDR => {
-                    self.aac_processor.audio_specific_config_load()?;
+                    if self.aac_processor.bytes_reader.len() >= 2 {
+                        self.aac_processor.audio_specific_config_load()?;
+                    }
+
                     return Ok(FlvDemuxerAudioData::new());
                 }
                 aac_packet_type::AAC_RAW => {

--- a/library/container/flv/src/muxer.rs
+++ b/library/container/flv/src/muxer.rs
@@ -3,12 +3,36 @@ use {
     bytesio::bytes_writer::BytesWriter,
 };
 
-const FLV_HEADER: [u8; 9] = [
+const FLV_HEADER_AV: [u8; 9] = [
     0x46, // 'F'
     0x4c, //'L'
     0x56, //'V'
     0x01, //version
     0x05, //00000101  audio tag  and video tag
+    0x00, 0x00, 0x00, 0x09, //flv header size
+]; // 9
+const FLV_HEADER_JUST_AUDIO: [u8; 9] = [
+    0x46, // 'F'
+    0x4c, //'L'
+    0x56, //'V'
+    0x01, //version
+    0x04, //00000101  audio tag  and video tag
+    0x00, 0x00, 0x00, 0x09, //flv header size
+]; // 9
+const FLV_HEADER_JUST_VIDEO: [u8; 9] = [
+    0x46, // 'F'
+    0x4c, //'L'
+    0x56, //'V'
+    0x01, //version
+    0x01, //00000101  audio tag  and video tag
+    0x00, 0x00, 0x00, 0x09, //flv header size
+]; // 9
+const FLV_HEADER_EMPTY_AV: [u8; 9] = [
+    0x46, // 'F'
+    0x4c, //'L'
+    0x56, //'V'
+    0x01, //version
+    0x00, //00000101  audio tag  and video tag
     0x00, 0x00, 0x00, 0x09, //flv header size
 ]; // 9
 pub const HEADER_LENGTH: u32 = 11;
@@ -29,8 +53,20 @@ impl FlvMuxer {
         }
     }
 
-    pub fn write_flv_header(&mut self) -> Result<(), FlvMuxerError> {
-        self.writer.write(&FLV_HEADER)?;
+    pub fn write_flv_header(
+        &mut self,
+        has_audio: bool,
+        has_video: bool,
+    ) -> Result<(), FlvMuxerError> {
+        if has_audio && has_video {
+            self.writer.write(&FLV_HEADER_AV)?;
+        } else if has_audio {
+            self.writer.write(&FLV_HEADER_JUST_AUDIO)?;
+        } else if has_video {
+            self.writer.write(&FLV_HEADER_JUST_VIDEO)?;
+        } else {
+            self.writer.write(&FLV_HEADER_EMPTY_AV)?;
+        }
         Ok(())
     }
 

--- a/protocol/hls/src/flv2hls.rs
+++ b/protocol/hls/src/flv2hls.rs
@@ -137,6 +137,10 @@ impl Flv2HlsRemuxer {
                 dts = data.dts;
                 pid = self.audio_pid;
                 payload.extend_from_slice(&data.data[..]);
+
+                if dts - self.last_ts_dts >= self.duration * 1000 {
+                    self.need_new_segment = true;
+                }
             }
             _ => return Ok(()),
         }


### PR DESCRIPTION
## step to reproduce
`ffmpeg -stream_loop -1 -re -i music.aac -c copy -f flv -y rtmp://localhost/live/test`

## error logs
```
[2024-03-28T07:04:23Z INFO  rtmp::rtmp] session run error: session_type: server, app_name: live, stream_name: livestream, err: cache error name: mpeg aac error
```

## cause
the first two chunk stream's body length  is 2 and 4. `xiu` can't handle them.
the first packet: 0xAF, 0x00
the second packet: 0xAF, 0x00, 0x11, 0x90


## Solution
1. ignore the chunk payload with small size.
2. AAC profile workaround, there is a overflow error.
