### PR TITLE
fix: rtmp server failing to connect when auth is configured

### DIFF
--- a/protocol/rtmp/CHANGELOG.md
+++ b/protocol/rtmp/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 
+- Fix: RTMP Auth failing due to empty string query string in packet
+
 ## [0.6.3] - 2021-03-15
 - Upgrade failure library.
 - Support querying more detailed statistic data.


### PR DESCRIPTION
Fix 1: the app name contains the whole query param for whatever reason, this patch removes it.

Fix 2: somehow the query parameters passed to on_connect function are empty even though they exist and the auth fails because it thinks there's no `token` even tho there is, i just use the `connect_properties` url to get the required info instead.