### PR TITLE
feat: abstract streamhub message notifications

### DIFF
--- a/library/streamhub/src/define.rs
+++ b/library/streamhub/src/define.rs
@@ -225,6 +225,27 @@ pub enum PubDataType {
     Both,
 }
 
+#[derive(Clone, Serialize)]
+pub enum StreamHubEventMessage {
+    Subscribe {
+        identifier: StreamIdentifier,
+        info: SubscriberInfo,
+    },
+    UnSubscribe {
+        identifier: StreamIdentifier,
+        info: SubscriberInfo,
+    },
+    Publish {
+        identifier: StreamIdentifier,
+        info: PublisherInfo,
+    },
+    UnPublish {
+        identifier: StreamIdentifier,
+        info: PublisherInfo,
+    },
+    NotSupport {},
+}
+
 #[derive(Serialize)]
 pub enum StreamHubEvent {
     Subscribe {
@@ -264,6 +285,28 @@ pub enum StreamHubEvent {
         identifier: StreamIdentifier,
         sender: InformationSender,
     },
+}
+
+impl StreamHubEvent {
+    pub fn to_message(&self) -> StreamHubEventMessage {
+        match self {
+            StreamHubEvent::Subscribe { identifier, info, result_sender: _result_sender } => {
+                StreamHubEventMessage::Subscribe { identifier: identifier.clone(), info: info.clone() }
+            }
+            StreamHubEvent::UnSubscribe { identifier, info } => {
+                StreamHubEventMessage::UnSubscribe { identifier: identifier.clone(), info: info.clone() }
+            }
+            StreamHubEvent::Publish { identifier, info, result_sender: _result_sender, stream_handler: _stream_handler } => {
+                StreamHubEventMessage::Publish { identifier: identifier.clone(), info: info.clone() }
+            }
+            StreamHubEvent::UnPublish { identifier, info } => {
+                StreamHubEventMessage::UnPublish { identifier: identifier.clone(), info: info.clone() }
+            }
+            _ => {
+                StreamHubEventMessage::NotSupport {}
+            }
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/library/streamhub/src/notify/http.rs
+++ b/library/streamhub/src/notify/http.rs
@@ -1,0 +1,122 @@
+use crate::notify::Notifier;
+use reqwest::Client;
+use async_trait::async_trait;
+use crate::define::{StreamHubEventMessage};
+
+macro_rules! serialize_event {
+    ($message:expr) => {{
+        let event_serialize_str = match serde_json::to_string(&$message) {
+            Ok(data) => {
+                log::info!("event data: {}", data);
+                data
+            }
+            Err(_) => String::from("empty body"),
+        };
+        event_serialize_str
+    }};
+}
+
+
+pub struct HttpNotifier {
+    request_client: Client,
+    on_publish_url: Option<String>,
+    on_unpublish_url: Option<String>,
+    on_play_url: Option<String>,
+    on_stop_url: Option<String>,
+}
+
+impl HttpNotifier {
+    pub fn new(
+        on_publish_url: Option<String>,
+        on_unpublish_url: Option<String>,
+        on_play_url: Option<String>,
+        on_stop_url: Option<String>,
+    ) -> Self {
+        Self {
+            request_client: reqwest::Client::new(),
+            on_publish_url,
+            on_unpublish_url,
+            on_play_url,
+            on_stop_url,
+        }
+    }
+}
+
+#[async_trait]
+impl Notifier for HttpNotifier {
+    async fn on_publish_notify(&self, event: &StreamHubEventMessage) {
+        if let Some(on_publish_url) = &self.on_publish_url {
+            match self
+                .request_client
+                .post(on_publish_url)
+                .body(serialize_event!(event))
+                .send()
+                .await
+            {
+                Err(err) => {
+                    log::error!("on_publish error: {}", err);
+                }
+                Ok(response) => {
+                    log::info!("on_publish success: {:?}", response);
+                }
+            }
+        }
+    }
+
+    async fn on_unpublish_notify(&self, event: &StreamHubEventMessage) {
+        if let Some(on_unpublish_url) = &self.on_unpublish_url {
+            match self
+                .request_client
+                .post(on_unpublish_url)
+                .body(serialize_event!(event))
+                .send()
+                .await
+            {
+                Err(err) => {
+                    log::error!("on_unpublish error: {}", err);
+                }
+                Ok(response) => {
+                    log::info!("on_unpublish success: {:?}", response);
+                }
+            }
+        }
+    }
+
+    async fn on_play_notify(&self, event: &StreamHubEventMessage) {
+        if let Some(on_play_url) = &self.on_play_url {
+            match self
+                .request_client
+                .post(on_play_url)
+                .body(serialize_event!(event))
+                .send()
+                .await
+            {
+                Err(err) => {
+                    log::error!("on_play error: {}", err);
+                }
+                Ok(response) => {
+                    log::info!("on_play success: {:?}", response);
+                }
+            }
+        }
+    }
+
+    async fn on_stop_notify(&self, event: &StreamHubEventMessage) {
+        if let Some(on_stop_url) = &self.on_stop_url {
+            match self
+                .request_client
+                .post(on_stop_url)
+                .body(serialize_event!(event))
+                .send()
+                .await
+            {
+                Err(err) => {
+                    log::error!("on_stop error: {}", err);
+                }
+                Ok(response) => {
+                    log::info!("on_stop success: {:?}", response);
+                }
+            }
+        }
+    }
+}

--- a/library/streamhub/src/notify/mod.rs
+++ b/library/streamhub/src/notify/mod.rs
@@ -1,100 +1,12 @@
-use reqwest::Client;
-pub struct Notifier {
-    request_client: Client,
-    on_publish_url: Option<String>,
-    on_unpublish_url: Option<String>,
-    on_play_url: Option<String>,
-    on_stop_url: Option<String>,
-}
+pub mod http;
 
-impl Notifier {
-    pub fn new(
-        on_publish_url: Option<String>,
-        on_unpublish_url: Option<String>,
-        on_play_url: Option<String>,
-        on_stop_url: Option<String>,
-    ) -> Self {
-        Self {
-            request_client: reqwest::Client::new(),
-            on_publish_url,
-            on_unpublish_url,
-            on_play_url,
-            on_stop_url,
-        }
-    }
-    pub async fn on_publish_notify(&self, body: String) {
-        if let Some(on_publish_url) = &self.on_publish_url {
-            match self
-                .request_client
-                .post(on_publish_url)
-                .body(body)
-                .send()
-                .await
-            {
-                Err(err) => {
-                    log::error!("on_publish error: {}", err);
-                }
-                Ok(response) => {
-                    log::info!("on_publish success: {:?}", response);
-                }
-            }
-        }
-    }
+use async_trait::async_trait;
+use crate::define::{StreamHubEventMessage};
 
-    pub async fn on_unpublish_notify(&self, body: String) {
-        if let Some(on_unpublish_url) = &self.on_unpublish_url {
-            match self
-                .request_client
-                .post(on_unpublish_url)
-                .body(body)
-                .send()
-                .await
-            {
-                Err(err) => {
-                    log::error!("on_unpublish error: {}", err);
-                }
-                Ok(response) => {
-                    log::info!("on_unpublish success: {:?}", response);
-                }
-            }
-        }
-    }
-
-    pub async fn on_play_notify(&self, body: String) {
-        if let Some(on_play_url) = &self.on_play_url {
-            match self
-                .request_client
-                .post(on_play_url)
-                .body(body)
-                .send()
-                .await
-            {
-                Err(err) => {
-                    log::error!("on_play error: {}", err);
-                }
-                Ok(response) => {
-                    log::info!("on_play success: {:?}", response);
-                }
-            }
-        }
-    }
-
-    pub async fn on_stop_notify(&self, body: String) {
-        if let Some(on_stop_url) = &self.on_stop_url {
-            match self
-                .request_client
-                .post(on_stop_url)
-                .body(body)
-                .send()
-                .await
-            {
-                Err(err) => {
-                    log::error!("on_stop error: {}", err);
-                }
-                Ok(response) => {
-                    log::info!("on_stop success: {:?}", response);
-                }
-            }
-        }
-    }
+#[async_trait]
+pub trait Notifier: Sync + Send {
+    async fn on_publish_notify(&self, event: &StreamHubEventMessage);
+    async fn on_unpublish_notify(&self, event: &StreamHubEventMessage);
+    async fn on_play_notify(&self, event: &StreamHubEventMessage);
+    async fn on_stop_notify(&self, event: &StreamHubEventMessage);
 }


### PR DESCRIPTION
example
```rust
let notifier: Option<Arc<dyn Notifier>> = if let Some(httpnotifier) = &self.cfg.httpnotify {
    if !httpnotifier.enabled {
    None
    } else {
    // Or a custom-defined Notifier
    Some(Arc::new(HttpNotifier::new(
        httpnotifier.on_publish.clone(),
        httpnotifier.on_unpublish.clone(),
        httpnotifier.on_play.clone(),
        httpnotifier.on_stop.clone(),
    )))
    }
} else {
    None
};
```

The Notify trait can be customized by the users of the library.