### PR TITLE
Allow setting different passwords for pushing and pulling

### DIFF
--- a/application/xiu/src/config/mod.rs
+++ b/application/xiu/src/config/mod.rs
@@ -187,6 +187,7 @@ pub struct HttpNotifierConfig {
 pub struct AuthSecretConfig {
     pub key: String,
     pub password: String,
+    pub push_password: Option<String>
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]

--- a/application/xiu/src/service.rs
+++ b/application/xiu/src/service.rs
@@ -52,6 +52,7 @@ impl Service {
             Some(Auth::new(
                 authsecret.key.clone(),
                 authsecret.password.clone(),
+                authsecret.push_password.clone(),
                 cfg.algorithm.clone(),
                 auth_type,
             ))


### PR DESCRIPTION
With these changes it's possible to specify an optional `push_password` in the `[authsecret]` section of the config file which if given is used to authenticate pushing streams.