### PR TITLE
Add authorization header support

### DIFF
--- a/library/common/src/errors.rs
+++ b/library/common/src/errors.rs
@@ -12,6 +12,8 @@ pub enum AuthErrorValue {
     TokenIsNotCorrect,
     #[fail(display = "no token found.")]
     NoTokenFound,
+    #[fail(display = "invalid token format.")]
+    InvalidTokenFormat
 }
 
 impl fmt::Display for AuthError {

--- a/protocol/hls/src/server.rs
+++ b/protocol/hls/src/server.rs
@@ -6,7 +6,7 @@ use {
         http::StatusCode,
         response::Response,
     },
-    commonlib::auth::Auth,
+    commonlib::auth::{Auth, SecretCarrier},
     std::net::SocketAddr,
     tokio::{fs::File, net::TcpListener},
     tokio_util::codec::{BytesCodec, FramedRead},
@@ -36,7 +36,11 @@ async fn handle_connection(State(auth): State<Option<Auth>>, req: Request<Body>)
 
             if let Some(auth_val) = auth {
                 if auth_val
-                    .authenticate(&stream_name, &query_string, true)
+                    .authenticate(
+                        &stream_name,
+                        &query_string.map(|q| SecretCarrier::Query(q)),
+                        true,
+                    )
                     .is_err()
                 {
                     return Response::builder()

--- a/protocol/httpflv/src/server.rs
+++ b/protocol/httpflv/src/server.rs
@@ -7,7 +7,7 @@ use {
         http::StatusCode,
         response::Response,
     },
-    commonlib::auth::Auth,
+    commonlib::auth::{Auth, SecretCarrier},
     futures::channel::mpsc::unbounded,
     std::net::SocketAddr,
     streamhub::define::StreamHubEventSender,
@@ -37,7 +37,11 @@ async fn handle_connection(
 
             if let Some(auth_val) = auth {
                 if auth_val
-                    .authenticate(&stream_name, &query_string, true)
+                    .authenticate(
+                        &stream_name,
+                        &query_string.map(|q| SecretCarrier::Query(q)),
+                        true,
+                    )
                     .is_err()
                 {
                     return Response::builder()

--- a/protocol/rtmp/src/session/server_session.rs
+++ b/protocol/rtmp/src/session/server_session.rs
@@ -1,3 +1,5 @@
+use commonlib::auth::SecretCarrier;
+
 use crate::chunk::{errors::UnpackErrorValue, packetizer::ChunkPacketizer};
 
 use {
@@ -626,7 +628,14 @@ impl ServerSession {
         (self.stream_name, self.query) =
             RtmpUrlParser::parse_stream_name_with_query(&raw_stream_name);
         if let Some(auth) = &self.auth {
-            auth.authenticate(&self.stream_name, &self.query, true)?
+            auth.authenticate(
+                &self.stream_name,
+                &self
+                    .query
+                    .as_ref()
+                    .map(|q| SecretCarrier::Query(q.to_string())),
+                true,
+            )?
         }
 
         let query = if let Some(query_val) = &self.query {
@@ -699,7 +708,14 @@ impl ServerSession {
             }
         }
         if let Some(auth) = &self.auth {
-            auth.authenticate(&self.stream_name, &self.query, false)?
+            auth.authenticate(
+                &self.stream_name,
+                &self
+                    .query
+                    .as_ref()
+                    .map(|q| SecretCarrier::Query(q.to_string())),
+                false,
+            )?
         }
 
         /*Now it can update the request url*/

--- a/protocol/rtsp/src/session/mod.rs
+++ b/protocol/rtsp/src/session/mod.rs
@@ -7,6 +7,7 @@ use crate::global_trait::Unmarshal;
 use crate::rtp::define::ANNEXB_NALU_START_CODE;
 use crate::rtp::utils::Marshal as RtpMarshal;
 
+use commonlib::auth::SecretCarrier;
 use commonlib::http::HttpRequest as RtspRequest;
 use commonlib::http::HttpResponse as RtspResponse;
 use commonlib::http::Marshal as RtspMarshal;
@@ -314,7 +315,15 @@ impl RtspServerSession {
     async fn handle_announce(&mut self, rtsp_request: &RtspRequest) -> Result<(), SessionError> {
         if let Some(auth) = &self.auth {
             let stream_name = rtsp_request.uri.path.clone();
-            auth.authenticate(&stream_name, &rtsp_request.uri.query, false)?;
+            auth.authenticate(
+                &stream_name,
+                &rtsp_request
+                    .uri
+                    .query
+                    .as_ref()
+                    .map(|q| SecretCarrier::Query(q.to_string())),
+                false,
+            )?;
         }
 
         if let Some(request_body) = &rtsp_request.body {
@@ -465,7 +474,15 @@ impl RtspServerSession {
     async fn handle_play(&mut self, rtsp_request: &RtspRequest) -> Result<(), SessionError> {
         if let Some(auth) = &self.auth {
             let stream_name = rtsp_request.uri.path.clone();
-            auth.authenticate(&stream_name, &rtsp_request.uri.query, true)?;
+            auth.authenticate(
+                &stream_name,
+                &rtsp_request
+                    .uri
+                    .query
+                    .as_ref()
+                    .map(|q| SecretCarrier::Query(q.to_string())),
+                true,
+            )?;
         }
 
         for track in self.tracks.values_mut() {

--- a/protocol/webrtc/src/clients/index.html
+++ b/protocol/webrtc/src/clients/index.html
@@ -88,9 +88,11 @@
         <label for="app-name">App Name:</label>
         <input type="text" id="app-name" name="app-name" value="live">
         <label for="stream-name">Stream Name:</label>
-        <input type="text" id="stream-name" name="stream-name" value="test">
+        <input type="text" id="stream-name" name="stream-name" value="test"><br>
         <label for="token">Token:</label>
         <input type="text" id="token" name="token" value="123">
+        <label for="use-header">Use Authorization header:</label>
+        <input type="checkbox" id="use-header" name="use-header">
         <br><br>
         <button id="start-whep-btn">Start WHEP</button>
     </div>
@@ -106,6 +108,7 @@
             const appName = document.getElementById("app-name").value;
             const streamName = document.getElementById("stream-name").value;
             const token = document.getElementById("token").value;
+            const useHeader = document.getElementById("use-header").checked;
 
             //Create peerconnection
             const pc = window.pc = new RTCPeerConnection();
@@ -126,11 +129,11 @@
             //Create whep client
             const whep = new WHEPClient();
 
-            const url = location.origin + "/whep?app=" + appName + "&stream=" + streamName + "&token=" + token;
+            const url = location.origin + "/whep?app=" + appName + "&stream=" + streamName + (!useHeader ? "&token=" + token : "");
             //const token = ""
 
             //Start viewing
-            whep.view(pc, url, token);
+            whep.view(pc, url, useHeader ? token : null);
 
         });
     </script>


### PR DESCRIPTION
This allows WHIP and WHEP clients to transmit the token either in the `Authorization` header or in the URI. The `Authorization` header takes precedence and as a fallback the URI `token` parameter will be used.