### PR TITLE
Rtsp udp remote address fix; rust 1.83 disable lint warning:non_local_definitions

### DIFF
--- a/application/xiu/src/config/errors.rs
+++ b/application/xiu/src/config/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use {
     failure::{Backtrace, Fail},
     std::{fmt, io::Error},

--- a/library/bytesio/src/bits_errors.rs
+++ b/library/bytesio/src/bits_errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use super::bytes_errors::BytesReadError;
 use super::bytes_errors::BytesWriteError;
 use failure::{Backtrace, Fail};

--- a/library/bytesio/src/bytes_errors.rs
+++ b/library/bytesio/src/bytes_errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use super::bytesio_errors::BytesIOError;
 use std::io;
 // use tokio::time::Elapsed;

--- a/library/bytesio/src/bytesio_errors.rs
+++ b/library/bytesio/src/bytesio_errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use failure::{Backtrace, Fail};
 use std::fmt;
 use std::io;

--- a/library/codec/h264/src/errors.rs
+++ b/library/codec/h264/src/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use bytesio::bits_errors::BitError;
 use failure::{Backtrace, Fail};
 use std::fmt;

--- a/library/common/src/errors.rs
+++ b/library/common/src/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use failure::{Backtrace, Fail};
 use std::fmt;
 

--- a/library/container/flv/src/amf0/errors.rs
+++ b/library/container/flv/src/amf0/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use {
     bytesio::bytes_errors::{BytesReadError, BytesWriteError},
     failure::{Backtrace, Fail},

--- a/library/container/flv/src/errors.rs
+++ b/library/container/flv/src/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use {
     bytesio::bits_errors::BitError,
     bytesio::bytes_errors::{BytesReadError, BytesWriteError},

--- a/library/container/mpegts/src/errors.rs
+++ b/library/container/mpegts/src/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use {
     bytesio::bytes_errors::{BytesReadError, BytesWriteError},
     failure::{Backtrace, Fail},

--- a/library/logger/src/errors.rs
+++ b/library/logger/src/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use failure::Fail;
 
 pub struct LogError {

--- a/library/streamhub/src/errors.rs
+++ b/library/streamhub/src/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use bytesio::bytes_errors::BytesReadError;
 use bytesio::bytes_errors::BytesWriteError;
 use failure::Backtrace;

--- a/protocol/hls/src/errors.rs
+++ b/protocol/hls/src/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use {
     failure::{Backtrace, Fail},
     std::fmt,

--- a/protocol/httpflv/src/errors.rs
+++ b/protocol/httpflv/src/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use streamhub::errors::StreamHubError;
 
 use {

--- a/protocol/rtmp/src/cache/errors.rs
+++ b/protocol/rtmp/src/cache/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use {
     crate::chunk::errors::PackError,
     bytesio::bytes_errors::BytesReadError,

--- a/protocol/rtmp/src/chunk/errors.rs
+++ b/protocol/rtmp/src/chunk/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use {
     failure::{Backtrace, Fail},
     bytesio::bytes_errors::{BytesReadError, BytesWriteError},

--- a/protocol/rtmp/src/handshake/errors.rs
+++ b/protocol/rtmp/src/handshake/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use {
     bytesio::bytes_errors::{BytesReadError, BytesWriteError},
     failure::{Backtrace, Fail},

--- a/protocol/rtmp/src/messages/errors.rs
+++ b/protocol/rtmp/src/messages/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use {
     crate::{
         protocol_control_messages::errors::ProtocolControlMessageReaderError,

--- a/protocol/rtmp/src/netconnection/errors.rs
+++ b/protocol/rtmp/src/netconnection/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use {
     crate::chunk::errors::PackError,
     failure::{Backtrace, Fail},

--- a/protocol/rtmp/src/netstream/errors.rs
+++ b/protocol/rtmp/src/netstream/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use {
     crate::chunk::errors::PackError,
     failure::{Backtrace, Fail},

--- a/protocol/rtmp/src/protocol_control_messages/errors.rs
+++ b/protocol/rtmp/src/protocol_control_messages/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use {
     failure::{Backtrace, Fail},
     bytesio::bytes_errors::{BytesReadError, BytesWriteError},

--- a/protocol/rtmp/src/relay/errors.rs
+++ b/protocol/rtmp/src/relay/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use {
     failure::Fail,
     std::{fmt, io::Error},

--- a/protocol/rtmp/src/remuxer/errors.rs
+++ b/protocol/rtmp/src/remuxer/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use {
     crate::{cache::errors::MetadataError, session::errors::SessionError},
     bytesio::bytes_errors::{BytesReadError, BytesWriteError},

--- a/protocol/rtmp/src/session/errors.rs
+++ b/protocol/rtmp/src/session/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use {
     crate::{
         cache::errors::CacheError,

--- a/protocol/rtmp/src/user_control_messages/errors.rs
+++ b/protocol/rtmp/src/user_control_messages/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use {
     bytesio::bytes_errors::{BytesReadError, BytesWriteError},
     failure::{Backtrace, Fail},

--- a/protocol/rtmp/src/utils/errors.rs
+++ b/protocol/rtmp/src/utils/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use {
     failure::{Backtrace, Fail},
     std::fmt,

--- a/protocol/rtsp/src/relay/errors.rs
+++ b/protocol/rtsp/src/relay/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use {
     failure::Fail,
     std::{fmt, io::Error},

--- a/protocol/rtsp/src/rtp/errors.rs
+++ b/protocol/rtsp/src/rtp/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use {
     failure::{Backtrace, Fail},
     std::fmt,

--- a/protocol/rtsp/src/rtp/rtcp/errors.rs
+++ b/protocol/rtsp/src/rtp/rtcp/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use bytesio::bytes_errors::BytesReadError;
 use bytesio::bytes_errors::BytesWriteError;
 use failure::Fail;

--- a/protocol/rtsp/src/session/errors.rs
+++ b/protocol/rtsp/src/session/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use {
     crate::rtp::errors::{PackerError, UnPackerError},
     bytesio::bytes_errors::BytesReadError,

--- a/protocol/webrtc/src/errors.rs
+++ b/protocol/webrtc/src/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use {
     audiopus::error::Error as OpusError,
     failure::{Backtrace, Fail},

--- a/protocol/webrtc/src/session/errors.rs
+++ b/protocol/webrtc/src/session/errors.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 use streamhub::errors::StreamHubError;
 use {
     bytesio::bytes_errors::BytesReadError,


### PR DESCRIPTION
- RTSP的UDP传输功能实现中的udp远端地址使用方法有误。
- CPU性能受限时，接收InterleavedBinaryData数据包的时候假设数据是一次能读到的，与实际测试不符。
- rust更新1.83后有很多warning:non_local_definitions，暂时先忽略