### PR TITLE
Enable LTO and codegen-units = 1 optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,7 @@ members = [
   "library/streamhub",
   "library/common",
 ]
+
+[profile.release]
+codegen-units = 1
+lto = true


### PR DESCRIPTION
Resolves https://github.com/harlanc/xiu/issues/154

Additionally, I decided to enable `codegen-units = 1` since it improves things even further with LTO.