### PR TITLE
Log actual `TcpListener` local addresses for clarity

### DIFF
--- a/application/xiu/src/api.rs
+++ b/application/xiu/src/api.rs
@@ -298,7 +298,12 @@ pub async fn run(producer: StreamHubEventSender, port: usize) {
         .route("/api/start_relay_stream", post(start_relay_stream))
         .route("/api/stop_relay_stream", post(stop_relay_stream));
 
-    log::info!("Http api server listening on http://0.0.0.0:{}", port);
-    let listener = tokio::net::TcpListener::bind((Ipv4Addr::UNSPECIFIED, port as u16)).await.unwrap();
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::UNSPECIFIED, port as u16))
+        .await
+        .unwrap();
+    log::info!(
+        "Http api server listening on http://{}",
+        listener.local_addr().unwrap()
+    );
     axum::serve(listener, app).await.unwrap();
 }

--- a/protocol/hls/src/server.rs
+++ b/protocol/hls/src/server.rs
@@ -7,7 +7,10 @@ use {
         response::Response,
     },
     commonlib::auth::{Auth, SecretCarrier},
-    std::net::SocketAddr,
+    std::{
+        convert::TryInto,
+        net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    },
     tokio::{fs::File, net::TcpListener},
     tokio_util::codec::{BytesCodec, FramedRead},
 };
@@ -146,12 +149,15 @@ async fn handle_connection(State(auth): State<Option<Auth>>, req: Request<Body>)
 }
 
 pub async fn run(port: usize, auth: Option<Auth>) -> Result<()> {
-    let listen_address = format!("0.0.0.0:{port}");
-    let sock_addr: SocketAddr = listen_address.parse().unwrap();
+    let sock_addr: SocketAddr = SocketAddrV4::new(
+        Ipv4Addr::UNSPECIFIED,
+        port.try_into().expect("Port should be a u16"),
+    )
+    .into();
 
     let listener = TcpListener::bind(sock_addr).await?;
 
-    log::info!("Hls server listening on http://{}", sock_addr);
+    log::info!("Hls server listening on http://{}", listener.local_addr()?);
 
     let handle_connection = handle_connection.with_state(auth);
 

--- a/protocol/httpflv/src/server.rs
+++ b/protocol/httpflv/src/server.rs
@@ -9,7 +9,10 @@ use {
     },
     commonlib::auth::{Auth, SecretCarrier},
     futures::channel::mpsc::unbounded,
-    std::net::SocketAddr,
+    std::{
+        convert::TryInto,
+        net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    },
     streamhub::define::StreamHubEventSender,
     tokio::net::TcpListener,
 };
@@ -37,11 +40,7 @@ async fn handle_connection(
 
             if let Some(auth_val) = auth {
                 if auth_val
-                    .authenticate(
-                        &stream_name,
-                        &query_string.map(SecretCarrier::Query),
-                        true,
-                    )
+                    .authenticate(&stream_name, &query_string.map(SecretCarrier::Query), true)
                     .is_err()
                 {
                     return Response::builder()
@@ -87,12 +86,18 @@ pub async fn run(
     port: usize,
     auth: Option<Auth>,
 ) -> Result<()> {
-    let listen_address = format!("0.0.0.0:{port}");
-    let sock_addr: SocketAddr = listen_address.parse().unwrap();
+    let sock_addr: SocketAddr = SocketAddrV4::new(
+        Ipv4Addr::UNSPECIFIED,
+        port.try_into().expect("Port should be a u16"),
+    )
+    .into();
 
     let listener = TcpListener::bind(sock_addr).await?;
 
-    log::info!("Httpflv server listening on http://{}", sock_addr);
+    log::info!(
+        "Httpflv server listening on http://{}",
+        listener.local_addr()?
+    );
 
     let handle_connection = handle_connection.with_state((event_producer.clone(), auth));
 

--- a/protocol/rtmp/src/rtmp.rs
+++ b/protocol/rtmp/src/rtmp.rs
@@ -32,7 +32,8 @@ impl RtmpServer {
         let socket_addr: &SocketAddr = &self.address.parse().unwrap();
         let listener = TcpListener::bind(socket_addr).await?;
 
-        log::info!("Rtmp server listening on tcp://{}", socket_addr);
+        log::info!("Rtmp server listening on tcp://{}", listener.local_addr()?);
+
         loop {
             let (tcp_stream, _) = listener.accept().await?;
             //tcp_stream.set_keepalive(Some(Duration::from_secs(30)))?;

--- a/protocol/rtsp/src/rtsp.rs
+++ b/protocol/rtsp/src/rtsp.rs
@@ -25,7 +25,8 @@ impl RtspServer {
         let socket_addr: &SocketAddr = &self.address.parse().unwrap();
         let listener = TcpListener::bind(socket_addr).await?;
 
-        log::info!("Rtsp server listening on tcp://{}", socket_addr);
+        log::info!("Rtsp server listening on tcp://{}", listener.local_addr()?);
+
         loop {
             let (tcp_stream, _) = listener.accept().await?;
             let mut session =

--- a/protocol/webrtc/src/webrtc.rs
+++ b/protocol/webrtc/src/webrtc.rs
@@ -33,7 +33,11 @@ impl WebRTCServer {
         let socket_addr: &SocketAddr = &self.address.parse().unwrap();
         let listener = TcpListener::bind(socket_addr).await?;
 
-        log::info!("WebRTC server listening on tcp://{}", socket_addr);
+        log::info!(
+            "WebRTC server listening on tcp://{}",
+            listener.local_addr()?
+        );
+
         loop {
             let (tcp_stream, _) = listener.accept().await?;
             let session = Arc::new(Mutex::new(WebRTCServerSession::new(


### PR DESCRIPTION
consider the following minimal config

```toml
[rtmp]
enabled = true
port = 0

# for simplicity, let's imagine rtsp and other stuff is just disabled

[httpapi]
port = 0
```

specifying port 0 means the system will assign any free port. this is cool and all but the logs don't reflect the truth

```bash
$ xiu --config the-config-from-above.toml
[2026-04-28T07:43:58Z INFO  rtmp::rtmp] Rtmp server listening on tcp://0.0.0.0:0
[2026-04-28T07:43:58Z INFO  xiu::api] Http api server listening on http://0.0.0.0:0
```

this is just wrong information because: we can't actually bind to port 0, and we can't have two sockets on one port.

instead, here's _the truth_:

```bash
lsof -i -P | grep xiu
xiu       89412  doc    9u  IPv4 0xccdde83db1f0d39a      0t0    TCP *:60689 (LISTEN)
xiu       89412  doc   10u  IPv4 0xa36499b626ff5706      0t0    TCP *:60690 (LISTEN)
```

so as we see, the system properly assigns the ports, but logs don't reflect it.

the fix is simple: instead of printing the info from the config, we can show the actual port the `TcpListener` binds to

this change can make the app more automation-friendly...

---

also no reason to parse `SocketAddr` from string when you know you can use the `UNSPECIFIED` address, and the port is already given