### PR TITLE
fix GOP cache memory leak for audio-only streams

### DIFF
--- a/application/xiu/src/service.rs
+++ b/application/xiu/src/service.rs
@@ -123,6 +123,7 @@ impl Service {
             } else {
                 1
             };
+            let gop_max_frame_num = rtmp_cfg_value.gop_max_frame_num;
 
             let producer = stream_hub.get_hub_event_sender();
 
@@ -182,7 +183,8 @@ impl Service {
             let address = format!("0.0.0.0:{listen_port}");
 
             let auth = Self::gen_auth(&rtmp_cfg_value.auth, &self.cfg.authsecret);
-            let mut rtmp_server = RtmpServer::new(address, producer, gop_num, auth);
+            let mut rtmp_server =
+                RtmpServer::new(address, producer, gop_num, gop_max_frame_num, auth);
             tokio::spawn(async move {
                 if let Err(err) = rtmp_server.run().await {
                     log::error!("rtmp server error: {}", err);

--- a/library/config/examples/config.toml
+++ b/library/config/examples/config.toml
@@ -6,6 +6,11 @@
 enabled = true
 port = 1935
 gop_num = 0
+# Maximum number of frames cached per GOP. Bounds memory for audio-only streams,
+# which never produce a video key frame to rotate the cache. Only takes effect
+# when gop_num > 0 (the cache is disabled when gop_num = 0). Optional; defaults
+# to a built-in value when unset.
+gop_max_frame_num = 2000
 [rtmp.auth]
 pull_enabled = false
 push_enabled = false

--- a/library/config/src/lib.rs
+++ b/library/config/src/lib.rs
@@ -33,6 +33,7 @@ impl Config {
             rtmp_config = Some(RtmpConfig {
                 enabled: true,
                 gop_num: Some(1),
+                gop_max_frame_num: None,
                 port: rtmp_port,
                 pull: None,
                 push: None,
@@ -106,6 +107,9 @@ pub struct RtmpConfig {
     pub enabled: bool,
     pub port: usize,
     pub gop_num: Option<usize>,
+    // Maximum number of frames cached per GOP; bounds memory for audio-only
+    // streams that never produce a video key frame. Defaults when unset.
+    pub gop_max_frame_num: Option<usize>,
     pub pull: Option<RtmpPullConfig>,
     pub push: Option<Vec<RtmpPushConfig>>,
     pub auth: Option<AuthConfig>,

--- a/protocol/rtmp/src/cache/gop.rs
+++ b/protocol/rtmp/src/cache/gop.rs
@@ -1,4 +1,19 @@
 use {std::collections::VecDeque, streamhub::define::FrameData};
+
+// Default upper bound on the number of frames a single GOP may hold.
+// The GOP cache normally rotates when a video key frame arrives. Audio-only
+// streams never produce a key frame, so without this cap a single GOP would
+// accumulate every frame indefinitely and leak memory until OOM (issue #190).
+// A realistic video GOP rotates on its key frame long before reaching the cap,
+// so it only affects pathological streams. Overridable via gop_max_frame_num.
+//
+// This is a per-GOP cap, so the whole cache is bounded by gop_num * this value.
+// For audio-only streams it also bounds how much history a new subscriber gets
+// on join: at ~23 ms per AAC frame, 2000 frames is roughly 46 s. Lower it via
+// gop_max_frame_num if a low-latency audio start matters more than buffered
+// history.
+const DEFAULT_MAX_GOP_FRAME_NUM: usize = 2000;
+
 #[derive(Clone)]
 pub struct Gop {
     datas: Vec<FrameData>,
@@ -36,19 +51,29 @@ impl Gop {
 pub struct Gops {
     gops: VecDeque<Gop>,
     size: usize,
+    // Maximum number of frames allowed in a single GOP before it is rotated,
+    // even when no video key frame arrives. Bounds memory for audio-only
+    // streams (see DEFAULT_MAX_GOP_FRAME_NUM).
+    max_frame_num: usize,
 }
 
 impl Default for Gops {
     fn default() -> Self {
-        Self::new(1)
+        Self::new(1, None)
     }
 }
 
 impl Gops {
-    pub fn new(size: usize) -> Self {
+    // Creates a GOP cache holding at most `size` GOPs, each capped at
+    // `max_frame_num` frames. A None (config unset) or 0 cap falls back to the
+    // default; 0 would otherwise rotate on every frame and defeat the cache.
+    pub fn new(size: usize, max_frame_num: Option<usize>) -> Self {
         Self {
             gops: VecDeque::from([Gop::new()]),
             size,
+            max_frame_num: max_frame_num
+                .filter(|&num| num > 0)
+                .unwrap_or(DEFAULT_MAX_GOP_FRAME_NUM),
         }
     }
 
@@ -57,7 +82,22 @@ impl Gops {
             return;
         }
 
-        if is_key_frame {
+        // A video key frame starts a new GOP. For audio-only streams no key
+        // frame ever arrives, so we also rotate once the current GOP reaches
+        // its frame cap; otherwise it would grow without bound (issue #190).
+        //
+        // The cap only rotates on an audio frame. Video keeps rotating strictly
+        // on key frames, so a video GOP never gets split on a non-key frame:
+        // that would leave a new subscriber with a GOP that has no leading key
+        // frame and thus nothing decodable. This matters when gop_max_frame_num
+        // is configured smaller than the video key-frame interval.
+        let audio_gop_is_full = matches!(data, FrameData::Audio { .. })
+            && self
+                .gops
+                .back()
+                .is_some_and(|gop| gop.len() >= self.max_frame_num);
+
+        if is_key_frame || audio_gop_is_full {
             //todo It may be possible to optimize here
             if self.gops.len() == self.size {
                 self.gops.pop_front();
@@ -78,5 +118,116 @@ impl Gops {
 
     pub fn get_gops(&self) -> VecDeque<Gop> {
         self.gops.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::BytesMut;
+
+    fn audio_frame() -> FrameData {
+        FrameData::Audio {
+            timestamp: 0,
+            data: BytesMut::new(),
+        }
+    }
+
+    // Key-frame-ness is carried by the `is_key_frame` flag passed to
+    // save_frame_data, not by the payload, so a key frame and an inter frame
+    // build the same FrameData::Video and differ only in that flag.
+    fn video_key_frame() -> FrameData {
+        FrameData::Video {
+            timestamp: 0,
+            data: BytesMut::new(),
+        }
+    }
+
+    fn video_inter_frame() -> FrameData {
+        FrameData::Video {
+            timestamp: 0,
+            data: BytesMut::new(),
+        }
+    }
+
+    fn total_frames(gops: &Gops) -> usize {
+        gops.get_gops().iter().map(|gop| gop.len()).sum()
+    }
+
+    // Regression test for issue #190: an audio-only stream never produces a
+    // video key frame, so without a frame-count cap the single GOP grows
+    // without bound and eventually OOMs the process. Feed far more frames than
+    // the cap and assert the cache stays bounded.
+    #[test]
+    fn audio_only_stream_is_bounded() {
+        let mut gops = Gops::new(1, None);
+        for _ in 0..(DEFAULT_MAX_GOP_FRAME_NUM * 5) {
+            gops.save_frame_data(audio_frame(), false);
+        }
+        assert!(total_frames(&gops) <= DEFAULT_MAX_GOP_FRAME_NUM);
+    }
+
+    // The cap is configurable: a smaller value bounds the cache more tightly.
+    #[test]
+    fn configured_cap_is_respected() {
+        let cap = 10;
+        let mut gops = Gops::new(1, Some(cap));
+        for _ in 0..(cap * 10) {
+            gops.save_frame_data(audio_frame(), false);
+        }
+        assert!(total_frames(&gops) <= cap);
+    }
+
+    // A cap of 0 is nonsensical (it would rotate on every frame), so it falls
+    // back to the default rather than disabling the cache.
+    #[test]
+    fn zero_cap_falls_back_to_default() {
+        let mut gops = Gops::new(1, Some(0));
+        for _ in 0..(DEFAULT_MAX_GOP_FRAME_NUM * 2) {
+            gops.save_frame_data(audio_frame(), false);
+        }
+        let frames = total_frames(&gops);
+        assert!(frames > 1 && frames <= DEFAULT_MAX_GOP_FRAME_NUM);
+    }
+
+    // Normal video behavior is unchanged: each key frame opens a new GOP and
+    // the number of retained GOPs never exceeds the configured size.
+    #[test]
+    fn key_frame_rotation_bounds_gop_count() {
+        let size = 3;
+        let mut gops = Gops::new(size, None);
+        for _ in 0..10 {
+            gops.save_frame_data(video_key_frame(), true);
+            for _ in 0..5 {
+                gops.save_frame_data(audio_frame(), false);
+            }
+        }
+        assert!(gops.get_gops().len() <= size);
+    }
+
+    // The frame cap must never split a video GOP on a non-key frame, even when
+    // gop_max_frame_num is misconfigured below the key-frame interval: doing so
+    // would leave a new subscriber with a GOP that has no leading key frame and
+    // nothing decodable. Video rotates strictly on key frames, so a long run of
+    // inter frames past the cap stays in the single key-frame-headed GOP.
+    #[test]
+    fn video_gop_is_not_split_by_frame_cap() {
+        let cap = 10;
+        let mut gops = Gops::new(1, Some(cap));
+        gops.save_frame_data(video_key_frame(), true);
+        for _ in 0..(cap * 5) {
+            gops.save_frame_data(video_inter_frame(), false);
+        }
+        assert_eq!(gops.get_gops().len(), 1);
+        assert_eq!(total_frames(&gops), cap * 5 + 1);
+    }
+
+    // gop_num = 0 disables caching entirely.
+    #[test]
+    fn disabled_cache_stores_nothing() {
+        let mut gops = Gops::new(0, None);
+        gops.save_frame_data(audio_frame(), false);
+        gops.save_frame_data(video_key_frame(), true);
+        assert_eq!(total_frames(&gops), 0);
     }
 }

--- a/protocol/rtmp/src/cache/mod.rs
+++ b/protocol/rtmp/src/cache/mod.rs
@@ -32,7 +32,11 @@ pub struct Cache {
 }
 
 impl Cache {
-    pub fn new(gop_num: usize, statistic_data_sender: Option<StatisticDataSender>) -> Self {
+    pub fn new(
+        gop_num: usize,
+        gop_max_frame_num: Option<usize>,
+        statistic_data_sender: Option<StatisticDataSender>,
+    ) -> Self {
         Cache {
             metadata: metadata::MetaData::new(),
             metadata_timestamp: 0,
@@ -40,7 +44,7 @@ impl Cache {
             video_timestamp: 0,
             audio_seq: BytesMut::new(),
             audio_timestamp: 0,
-            gops: Gops::new(gop_num),
+            gops: Gops::new(gop_num, gop_max_frame_num),
             statistic_data_sender,
         }
     }

--- a/protocol/rtmp/src/remuxer/rtsp2rtmp.rs
+++ b/protocol/rtmp/src/remuxer/rtsp2rtmp.rs
@@ -92,7 +92,7 @@ impl Rtsp2RtmpRemuxerSession {
 
     pub async fn publish_rtmp(&mut self) -> Result<(), RtmpRemuxerError> {
         self.rtmp_handler
-            .publish_to_stream_hub(self.app_name.clone(), self.stream_name.clone(), 0)
+            .publish_to_stream_hub(self.app_name.clone(), self.stream_name.clone(), 0, None)
             .await?;
         Ok(())
     }

--- a/protocol/rtmp/src/remuxer/whip2rtmp.rs
+++ b/protocol/rtmp/src/remuxer/whip2rtmp.rs
@@ -105,7 +105,7 @@ impl Whip2RtmpRemuxerSession {
 
     pub async fn publish_rtmp(&mut self) -> Result<(), RtmpRemuxerError> {
         self.rtmp_handler
-            .publish_to_stream_hub(self.app_name.clone(), self.stream_name.clone(), 1)
+            .publish_to_stream_hub(self.app_name.clone(), self.stream_name.clone(), 1, None)
             .await?;
         Ok(())
     }

--- a/protocol/rtmp/src/rtmp.rs
+++ b/protocol/rtmp/src/rtmp.rs
@@ -10,6 +10,7 @@ pub struct RtmpServer {
     address: String,
     event_producer: StreamHubEventSender,
     gop_num: usize,
+    gop_max_frame_num: Option<usize>,
     auth: Option<Auth>,
 }
 
@@ -18,12 +19,14 @@ impl RtmpServer {
         address: String,
         event_producer: StreamHubEventSender,
         gop_num: usize,
+        gop_max_frame_num: Option<usize>,
         auth: Option<Auth>,
     ) -> Self {
         Self {
             address,
             event_producer,
             gop_num,
+            gop_max_frame_num,
             auth,
         }
     }
@@ -41,6 +44,7 @@ impl RtmpServer {
                 tcp_stream,
                 self.event_producer.clone(),
                 self.gop_num,
+                self.gop_max_frame_num,
                 self.auth.clone(),
             );
             tokio::spawn(async move {

--- a/protocol/rtmp/src/session/client_session.rs
+++ b/protocol/rtmp/src/session/client_session.rs
@@ -547,6 +547,7 @@ impl ClientSession {
                             self.app_name.clone(),
                             self.stream_name.clone(),
                             self.gop_num,
+                            None,
                         )
                         .await?
                 }

--- a/protocol/rtmp/src/session/common.rs
+++ b/protocol/rtmp/src/session/common.rs
@@ -408,6 +408,7 @@ impl Common {
         app_name: String,
         stream_name: String,
         gop_num: usize,
+        gop_max_frame_num: Option<usize>,
     ) -> Result<(), SessionError> {
         let (event_result_sender, event_result_receiver) = oneshot::channel();
         let info = self.get_publisher_info();
@@ -446,7 +447,7 @@ impl Common {
         }
 
         self.stream_handler
-            .set_cache(Cache::new(gop_num, statistic_data_sender))
+            .set_cache(Cache::new(gop_num, gop_max_frame_num, statistic_data_sender))
             .await;
         Ok(())
     }

--- a/protocol/rtmp/src/session/server_session.rs
+++ b/protocol/rtmp/src/session/server_session.rs
@@ -60,6 +60,9 @@ pub struct ServerSession {
     pub common: Common,
     /*configure how many gops will be cached.*/
     gop_num: usize,
+    /*configure the maximum number of frames cached per gop (bounds memory for
+    audio-only streams that never produce a video key frame).*/
+    gop_max_frame_num: Option<usize>,
     auth: Option<Auth>,
 }
 
@@ -68,6 +71,7 @@ impl ServerSession {
         stream: TcpStream,
         event_producer: StreamHubEventSender,
         gop_num: usize,
+        gop_max_frame_num: Option<usize>,
         auth: Option<Auth>,
     ) -> Self {
         let remote_addr = if let Ok(addr) = stream.peer_addr() {
@@ -99,6 +103,7 @@ impl ServerSession {
             has_remaing_data: false,
             connect_properties: ConnectProperties::default(),
             gop_num,
+            gop_max_frame_num,
             auth,
         }
     }
@@ -768,6 +773,7 @@ impl ServerSession {
                 self.app_name.clone(),
                 self.stream_name.clone(),
                 self.gop_num,
+                self.gop_max_frame_num,
             )
             .await?;
 


### PR DESCRIPTION
The GOP cache only rotated when a video key frame arrived. Audio frames are always saved with is_key_frame = false, so an audio-only stream never rotated its GOP and a single Gop accumulated every frame indefinitely, leaking memory until OOM.

Rotate the current GOP once it reaches a maximum frame count, in addition to the existing key-frame rotation. Normal video is unchanged, since a realistic GOP rotates on its key frame long before reaching the cap, and sequence headers are cached separately so eviction never breaks subscriber bootstrap.

The cap defaults to 2000 frames and is configurable via the new optional gop_max_frame_num RTMP config option. Adds unit tests for the cache/gop module.

Fixes #190